### PR TITLE
RecruitSanity

### DIFF
--- a/src/archipelago.cs
+++ b/src/archipelago.cs
@@ -135,6 +135,8 @@ public unsafe partial class ArchipelagoFFXModule : FhModule {
         public List<Location>  OverdriveMode;
         [JsonInclude]          
         public List<Location>  Other;
+        [JsonInclude]
+        public List<Location>  Recruit;
         [JsonInclude]          
         public List<Location>  SphereGrid;
         //public Dictionary<int, Location> Treasure;
@@ -157,6 +159,7 @@ public unsafe partial class ArchipelagoFFXModule : FhModule {
             Overdrive = [];
             OverdriveMode = [];
             Other = [];
+            Recruit = [];
             SphereGrid = [];
         }
     }
@@ -172,6 +175,7 @@ public unsafe partial class ArchipelagoFFXModule : FhModule {
         public Dictionary<int, ArchipelagoItem> overdrive =      seed.Overdrive.ToDictionary(    x => x.location_id, x => new ArchipelagoItem(x.item_id, x.item_name, x.player_name));
         public Dictionary<int, ArchipelagoItem> overdrive_mode = seed.OverdriveMode.ToDictionary(x => x.location_id, x => new ArchipelagoItem(x.item_id, x.item_name, x.player_name));
         public Dictionary<int, ArchipelagoItem> other =          seed.Other.ToDictionary(        x => x.location_id, x => new ArchipelagoItem(x.item_id, x.item_name, x.player_name));
+        public Dictionary<int, ArchipelagoItem> recruit =        seed.Recruit.ToDictionary(      x => x.location_id, x => new ArchipelagoItem(x.item_id, x.item_name, x.player_name));
         public Dictionary<int, ArchipelagoItem> sphere_grid =    seed.SphereGrid.ToDictionary(   x => x.location_id, x => new ArchipelagoItem(x.item_id, x.item_name, x.player_name));
 
         public bool location_to_item(int location, [MaybeNullWhen(false)] out ArchipelagoItem item) {
@@ -182,6 +186,7 @@ public unsafe partial class ArchipelagoFFXModule : FhModule {
                 (int)ArchipelagoLocationType.Overdrive     => overdrive,
                 (int)ArchipelagoLocationType.OverdriveMode => overdrive_mode,
                 (int)ArchipelagoLocationType.Other         => other,
+                (int)ArchipelagoLocationType.Recruit       => recruit,
                 (int)ArchipelagoLocationType.SphereGrid    => sphere_grid,
                 _ => null,
             };

--- a/src/client/client.cs
+++ b/src/client/client.cs
@@ -241,7 +241,8 @@ public unsafe static void connectHandlers() {
         Overdrive     = 0x4000,
         OverdriveMode = 0x5000,
         Other         = 0x6000,
-        SphereGrid    = 0x7000,
+        Recruit       = 0x7000,
+        SphereGrid    = 0x8000,
     }
 
     public static bool sendLocation(long locationId, ArchipelagoLocationType locationType) {


### PR DESCRIPTION
Adding locations for Blitzball Free Agent recruiting.
Dependant on related apworld PR
- https://github.com/Rurusachi/Archipelago/pull/5

Added hooks for each free agent, in a similar fashion to the celestial / primer hook sets.
Tested with a range of agents in different regions, working successfully, including regions with multiple agents (eg. Airship Bridge) & agents that exist in multiple regions (eg. Wakka & Rin)