### PR TITLE
Update Jecht Spheres to match Fh SaveData

### DIFF
--- a/src/hooks.cs
+++ b/src/hooks.cs
@@ -2942,7 +2942,7 @@ public unsafe partial class ArchipelagoFFXModule {
                 // Key Item
 
                 //Progressive Jecht's Sphere
-                if (item_id == 40992) {
+                if (item_id == 0xA020 && Globals.save_data->key_items.get((int)item_id)) {
                     save_data->jecht_spheres.collected_amount++;
                 }
 


### PR DESCRIPTION
Referring to https://github.com/peppy-enterprises/fahrenheit/pull/78

Reordered to match SaveData, as well as updating the relevant seen bits.
Also split the CT off to be unique for Jecht Sphere, to set the bits when the location is sent.

Obtaining Progressive Jecht's Sphere now points at the updated SaveData `jecht_spheres.collected_amount`

Resolves #22 again