### PR TITLE
Skip CotSF entrance Cutscene

### DIFF
--- a/src/hooks.cs
+++ b/src/hooks.cs
@@ -1839,7 +1839,7 @@ public unsafe partial class ArchipelagoFFXModule {
 
                 break;
             case "nagi0400":
-                set(code_ptr, 0x597D, [
+                set(code_ptr, [0x4402, 0x597D], [
                     AtelOp.JMP.build(0x0000),
                     .. atelNOPArray(13),
                     ]);


### PR DESCRIPTION
Skips the entering CotSF cutscene, based upon a Calm Lands quest progression flag

<img width="1480" height="118" alt="image" src="https://github.com/user-attachments/assets/1ebaa64a-7b58-4bc5-bead-1e0b5463dec8" />
