### PR TITLE
Fix MSBuild events on linux

### DIFF
--- a/Fahrenheit.Modules.ArchipelagoFFX.csproj
+++ b/Fahrenheit.Modules.ArchipelagoFFX.csproj
@@ -74,7 +74,7 @@
 			  Command="rsync -acu --delete '$(AssetsDir)/' '$(AssetDestination)' --exclude='$(LoadOrderFile)' --exclude='$(StartGameFile)'"
 			  ContinueOnError="true" IgnoreExitCode="true" />
 		<Copy SourceFiles="@(AssetFiles)"
-			  DestinationFiles="$(PublishDir)fahrenheit\mods\loadorder; $(PublishDir)fahrenheit\start_game.bat"
+			  DestinationFiles="$(PublishDir)fahrenheit\mods\$(LoadOrderFile); $(PublishDir)fahrenheit\$(StartGameFile)"
 			  ContinueOnError="true" />
 	</Target>
 


### PR DESCRIPTION
Mildly unrelated, but notable: the `--exclude` flag excludes the files from both being copied *and* from being deleted by the `--delete` flag.