### PR TITLE
Setup Dotnet CI for Push & PR Error Checking

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,7 +5,6 @@ name: .NET
 
 on:
   push:
-  pull_request:
 
 jobs:
   publish:


### PR DESCRIPTION
Resolves #133 

Runs `dotnet publish` for both Debug|Release on ubuntu-latest & windows-latest